### PR TITLE
Fix missing import

### DIFF
--- a/src/utils/offlineSync.js
+++ b/src/utils/offlineSync.js
@@ -1,6 +1,6 @@
 // src/utils/offlineSync.js
 import { db } from "../firebaseConfig";
-import { doc, setDoc, deleteDoc, updateDoc } from "firebase/firestore";
+import { doc, setDoc, deleteDoc, updateDoc, deleteField } from "firebase/firestore";
 
 class OfflineSync {
   constructor() {


### PR DESCRIPTION
## Summary
- fix import in offline sync module

## Testing
- `npm run lint --silent` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68657b64a0b8832a811df748800deb76