### PR TITLE
Switch celebration pop-up to toast

### DIFF
--- a/src/components/CelebrationSystem.jsx
+++ b/src/components/CelebrationSystem.jsx
@@ -1,6 +1,7 @@
 // src/components/CelebrationSystem.jsx
 import React, { useEffect, useState } from "react";
-import { Sparkles, Trophy, Star, Zap, Heart } from "lucide-react";
+import { Sparkles, Star, Zap, Heart } from "lucide-react";
+import { useToast } from "./ToastProvider.jsx";
 
 export const CelebrationSystem = ({
   isVisible,
@@ -10,28 +11,24 @@ export const CelebrationSystem = ({
   milestoneText = "",
 }) => {
   const [particles, setParticles] = useState([]);
-  const [showModal, setShowModal] = useState(false);
+  const { addToast } = useToast();
 
   useEffect(() => {
     if (isVisible) {
-      setShowModal(true);
       generateParticles();
+      addToast(getCelebrationMessage());
 
-      // Play celebration sound (if enabled)
       if (typeof window !== "undefined" && window.navigator.vibrate) {
         window.navigator.vibrate([100, 50, 100]);
       }
 
       const timer = setTimeout(() => {
-        setShowModal(false);
-        setTimeout(() => {
-          onComplete?.();
-        }, 300);
+        onComplete?.();
       }, 2000);
 
       return () => clearTimeout(timer);
     }
-  }, [isVisible, onComplete]);
+  }, [isVisible, onComplete, addToast]);
 
   const generateParticles = () => {
     const newParticles = Array.from({ length: 20 }, (_, i) => ({
@@ -100,9 +97,8 @@ export const CelebrationSystem = ({
   if (!isVisible) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
-      {/* Particles */}
-      <div className="absolute inset-0 overflow-hidden">
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <div className="absolute inset-0 overflow-hidden flex items-center justify-center">
         {particles.map((particle) => {
           const Icon = particle.icon;
           return (
@@ -123,39 +119,6 @@ export const CelebrationSystem = ({
             </div>
           );
         })}
-      </div>
-
-      {/* Celebration Modal */}
-      <div
-        className={`
-          bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-6 mx-4 max-w-sm w-full
-          transform transition-all duration-300 pointer-events-auto
-          ${showModal ? "scale-100 opacity-100" : "scale-95 opacity-0"}
-          border-4 border-gradient-to-r from-yellow-400 via-pink-500 to-purple-500
-        `}
-      >
-        <div className="text-center">
-          <div className="mb-4">
-            <Trophy
-              size={48}
-              className="mx-auto text-yellow-500 animate-bounce"
-            />
-          </div>
-
-          <h3 className="text-xl font-bold text-gray-800 dark:text-gray-100 mb-2">
-            {getCelebrationMessage()}
-          </h3>
-
-          <div className="flex justify-center space-x-2 mb-4">
-            <Sparkles className="text-yellow-400 animate-pulse" size={20} />
-            <Star className="text-yellow-400 animate-pulse" size={20} />
-            <Sparkles className="text-yellow-400 animate-pulse" size={20} />
-          </div>
-
-          <p className="text-gray-600 dark:text-gray-300 text-sm">
-            Keep up the amazing work! 💪
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/src/components/ToastProvider.jsx
+++ b/src/components/ToastProvider.jsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+
+const ToastContext = createContext(null);
+
+export const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+
+  const addToast = useCallback((message) => {
+    const id = Date.now() + Math.random();
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className="bg-gray-900 text-white px-4 py-2 rounded shadow-lg animate-fade-in-out"
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/src/index.css
+++ b/src/index.css
@@ -410,3 +410,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* --- Toast Animation --- */
+@keyframes fadeInOut {
+  0% { opacity: 0; transform: translateY(20px); }
+  10%,90% { opacity: 1; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-10px); }
+}
+
+.animate-fade-in-out {
+  animation: fadeInOut 3s forwards;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,11 +1,14 @@
 // src/main.jsx
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.jsx"; // Make sure this points to your App component file
-import "./index.css"; // Ensure this line exists
+import App from "./App.jsx";
+import { ToastProvider } from "./components/ToastProvider.jsx";
+import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add simple toast provider
- wrap the app in the provider
- update celebration system to trigger a toast and remove the trophy modal
- add small fade animation for toast

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868c39e27e8832a9569db82044444f7