### PR TITLE
fix: ensure compact variable always defined with fallback values

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -47,8 +47,12 @@ const DashboardPage = ({
   const uiPrefs = useUiPrefs();
   console.log('[DashboardPage] useUiPrefs returned:', uiPrefs);
 
-  const { compact, showRewards, showInsight } = uiPrefs;
-  console.log('[DashboardPage] Destructured values - compact:', compact, 'showRewards:', showRewards, 'showInsight:', showInsight);
+  // Use fallback values to ensure variables are always defined
+  const compact = uiPrefs?.compact ?? false;
+  const showRewards = uiPrefs?.showRewards ?? false;
+  const showInsight = uiPrefs?.showInsight ?? true;
+
+  console.log('[DashboardPage] Values - compact:', compact, 'showRewards:', showRewards, 'showInsight:', showInsight);
 
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [selectedHabitIdForStats, setSelectedHabitIdForStats] = useState(null);

--- a/src/pages/SettingsPage.jsx
+++ b/src/pages/SettingsPage.jsx
@@ -16,7 +16,16 @@ import { useUiPrefs } from "../hooks/useUiPrefs";
 
 const SettingsPage = ({ exportData, importData, habits = [] }) => {
   const fileInputRef = useRef(null);
-  const { compact, setCompact, showRewards, setShowRewards, showInsight, setShowInsight } = useUiPrefs();
+  const uiPrefs = useUiPrefs();
+
+  // Use fallback values to ensure variables are always defined
+  const compact = uiPrefs?.compact ?? false;
+  const setCompact = uiPrefs?.setCompact ?? (() => {});
+  const showRewards = uiPrefs?.showRewards ?? false;
+  const setShowRewards = uiPrefs?.setShowRewards ?? (() => {});
+  const showInsight = uiPrefs?.showInsight ?? true;
+  const setShowInsight = uiPrefs?.setShowInsight ?? (() => {});
+
   const [activeTab, setActiveTab] = useState("data");
 
   const handleUpdateHabitReminders = (reminders) => {


### PR DESCRIPTION
Changed destructuring pattern in DashboardPage and SettingsPage to use optional chaining (?.) and nullish coalescing (??) operators. This ensures that even if useUiPrefs returns undefined or null, compact will always have a valid boolean value.

Previous issue: Minifier was creating code where compact was undefined
in certain closures, causing 'ReferenceError: compact is not defined'

Fix:
- const compact = uiPrefs?.compact ?? false; Instead of:
- const { compact } = useUiPrefs();

This guarantees compact is always defined during Vite minification process.