### PR TITLE
fix: eliminate all inline ternary uses of compact variable in JSX

### DIFF
--- a/ERROR_DEBUGGING_GUIDE.md
+++ b/ERROR_DEBUGGING_GUIDE.md
@@ -1,0 +1,78 @@
+# How to See Full Error Details in Browser
+
+## Method 1: Browser Console (Most Common)
+
+1. **Open Developer Tools:**
+   - **Chrome/Edge:** Press `F12` or `Ctrl+Shift+I` (Windows) / `Cmd+Option+I` (Mac)
+   - **Firefox:** Press `F12` or `Ctrl+Shift+K` (Windows) / `Cmd+Option+K` (Mac)
+   - **Safari:** Enable Developer Menu first (Preferences > Advanced > Show Develop menu), then press `Cmd+Option+C`
+
+2. **Check Console Tab:**
+   - Look for red error messages
+   - Click on the error to expand the full stack trace
+   - Look for the file name and line number (e.g., `index.js:3726:37332`)
+
+3. **Check for Multiple Errors:**
+   - Scroll through the console
+   - Look for warnings (yellow) and errors (red)
+   - Some errors might be hidden - click "Show all" or similar
+
+## Method 2: Network Tab
+
+1. **Open Network Tab** in Developer Tools
+2. **Refresh the page** (F5)
+3. Look for:
+   - Failed requests (red)
+   - 404 errors
+   - CORS errors
+
+## Method 3: Sources/Debugger Tab
+
+1. **Open Sources Tab** (Chrome) or **Debugger Tab** (Firefox)
+2. **Enable "Pause on exceptions"** (checkbox at top)
+3. **Refresh page** - it will pause when error occurs
+4. You can see:
+   - Exact line where error happens
+   - Call stack (how we got there)
+   - Variable values at that moment
+
+## Method 4: React DevTools
+
+1. **Install React DevTools** extension
+2. **Open Components tab**
+3. Look for:
+   - Error boundaries showing errors
+   - Component tree (which components loaded)
+
+## Method 5: Check Error Boundary
+
+If you see a blank screen with no console errors:
+1. The ErrorBoundary might be catching the error
+2. Check if there's a fallback UI showing
+3. Look in console for "Error caught by boundary:" messages
+
+## Current Error Details Needed
+
+Please provide:
+1. **Full error message** from console
+2. **Stack trace** (click to expand error)
+3. **Network errors** (if any)
+4. **Console logs** starting with `[useUiPrefs]` and `[DashboardPage]`
+5. **Screenshot** of the console if possible
+
+## Quick Test Commands
+
+Open console and run these:
+```javascript
+// Check if compact is accessible
+window.compact
+
+// Check localStorage
+localStorage.getItem('ui.compact')
+
+// Check if React loaded
+window.React
+
+// Check all localStorage keys
+Object.keys(localStorage)
+```

--- a/src/components/HabitList.jsx
+++ b/src/components/HabitList.jsx
@@ -90,6 +90,10 @@ export const HabitList = ({
 }) => {
   console.log('[HabitList] Component rendering with compact:', compact);
 
+  // Pre-compute className values to avoid minification issues
+  const cardContentPadding = compact ? "px-3 pb-3 sm:px-4 sm:pb-4" : "px-4 pb-4 sm:px-6 sm:pb-6";
+  const listSpacing = compact ? "space-y-2" : "space-y-3";
+
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const calendarRef = useRef(null);
   const dateButtonRef = useRef(null);
@@ -175,13 +179,11 @@ export const HabitList = ({
 
       {/* *** REVERTED Rendering Logic: Directly map active habits *** */}
       <CardContent
-        className={`flex-grow overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent ${
-          compact ? "px-3 pb-3 sm:px-4 sm:pb-4" : "px-4 pb-4 sm:px-6 sm:pb-6"
-        } pt-0`}
+        className={`flex-grow overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent ${cardContentPadding} pt-0`}
       >
         {activeHabitsForSelectedDate.length > 0 ? (
           // Render directly as a list without grouping headers
-          <ul className={compact ? "space-y-2" : "space-y-3"}>
+          <ul className={listSpacing}>
             {activeHabitsForSelectedDate.map((habit) => (
               <HabitListItem
                 key={habit.id}

--- a/src/components/HabitListItem.jsx
+++ b/src/components/HabitListItem.jsx
@@ -36,6 +36,10 @@ export const HabitListItem = ({
   habitLog, // Add habitLog for streak calculation
   compact = false,
 }) => {
+  // Pre-compute className values to avoid minification issues
+  const itemPadding = compact ? "p-2" : "p-3";
+  const actionSpacing = compact ? "space-x-1" : "space-x-1 sm:space-x-2";
+
   // State for streak milestone modal
   const [showMilestoneModal, setShowMilestoneModal] = useState(false);
   const [reachedMilestone, setReachedMilestone] = useState(null);
@@ -207,7 +211,7 @@ export const HabitListItem = ({
   // --- Render ---
   return (
     <li
-      className={`flex flex-col sm:flex-row items-start sm:items-center justify-between ${compact ? "p-2" : "p-3"} rounded-lg border border-gray-200 dark:border-gray-700 gap-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors duration-150 ${selectedClass}`}
+      className={`flex flex-col sm:flex-row items-start sm:items-center justify-between ${itemPadding} rounded-lg border border-gray-200 dark:border-gray-700 gap-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors duration-150 ${selectedClass}`}
       onClick={handleSelect}
       role="button"
       tabIndex={0}
@@ -272,7 +276,7 @@ export const HabitListItem = ({
       </div>
 
       {/* Action Area (Right side) */}
-      <div className={`flex items-center ${compact ? "space-x-1" : "space-x-1 sm:space-x-2"} flex-shrink-0 w-full sm:w-auto justify-end`}>
+      <div className={`flex items-center ${actionSpacing} flex-shrink-0 w-full sm:w-auto justify-end`}>
         {/* Conditional Logging UI */}
         {isMeasurable ? (
           // --- UI for Measurable Habits ---

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -54,6 +54,13 @@ const DashboardPage = ({
 
   console.log('[DashboardPage] Values - compact:', compact, 'showRewards:', showRewards, 'showInsight:', showInsight);
 
+  // Pre-compute all className values to avoid minification issues
+  const containerGap = compact ? "gap-4" : "gap-6";
+  const headerPadding = compact ? "p-4" : "p-6";
+  const gridGap = compact ? "gap-4" : "gap-6";
+  const contentSpacing = compact ? "space-y-4" : "space-y-6";
+  const cardPadding = compact ? "p-3" : "p-4";
+
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [selectedHabitIdForStats, setSelectedHabitIdForStats] = useState(null);
   const [motivationalMessage, setMotivationalMessage] = useState("");
@@ -209,7 +216,7 @@ const DashboardPage = ({
   }, [isLoadingData, habitLog, loadDailyMotivation]); // useEffect is now defined
 
   return (
-    <div className={`flex flex-col ${compact ? "gap-4" : "gap-6"} h-full`}>
+    <div className={`flex flex-col ${containerGap} h-full`}>
       {/* Empty State - No habits */}
       {!isLoadingData && habits.length === 0 && (
         <div className="flex-1 flex items-center justify-center min-h-[500px]">
@@ -266,7 +273,7 @@ const DashboardPage = ({
       {!isLoadingData && habits.length > 0 && (
         <>
           {/* Welcome Header - Compact & Elegant */}
-          <div className={`bg-gradient-to-r from-indigo-50 via-blue-50 to-cyan-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 rounded-2xl ${compact ? "p-4" : "p-6"} border border-indigo-100 dark:border-gray-700 shadow-sm`}>
+          <div className={`bg-gradient-to-r from-indigo-50 via-blue-50 to-cyan-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 rounded-2xl ${headerPadding} border border-indigo-100 dark:border-gray-700 shadow-sm`}>
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div>
                 <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
@@ -288,9 +295,9 @@ const DashboardPage = ({
           </div>
 
           {/* Improved Dashboard Layout */}
-          <div className={`grid grid-cols-1 xl:grid-cols-4 ${compact ? "gap-4" : "gap-6"}`}>
+          <div className={`grid grid-cols-1 xl:grid-cols-4 ${gridGap}`}>
             {/* Left Main Content - 3/4 width */}
-            <div className={`xl:col-span-3 ${compact ? "space-y-4" : "space-y-6"}`}>
+            <div className={`xl:col-span-3 ${contentSpacing}`}>
               {/* Progress Overview - Compact Stats */}
               <GlobalStatsDashboard globalStats={globalStats} />
 
@@ -316,7 +323,7 @@ const DashboardPage = ({
                   </div>
                 </div>
 
-                <CardContent className={`${compact ? "p-3" : "p-4"}`}>
+                <CardContent className={cardPadding}>
                   {habits.length > 0 ? (
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                       {habits


### PR DESCRIPTION
Pre-computed all className values that use compact at the component level to avoid minification issues where compact becomes undefined in closures.

Changes:
- DashboardPage: Pre-compute containerGap, headerPadding, gridGap, contentSpacing, cardPadding
- HabitList: Pre-compute cardContentPadding, listSpacing
- HabitListItem: Pre-compute itemPadding, actionSpacing

This ensures compact is always resolved at component scope before being used in template literals, avoiding the 'ReferenceError: compact is not defined' error during Vite's minification process.

Also added ERROR_DEBUGGING_GUIDE.md to help users diagnose issues.